### PR TITLE
check if error exists in response data

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -108,6 +108,9 @@ def get_pages(country_code, next_page_token="&"):
     while next_page_token is not None:
         # A page of data i.e. a list of videos and all needed data
         video_data_page = api_request(next_page_token, country_code)
+        
+        if video_data_page.get('error'):
+            print(video_data_page['error'])
 
         # Get the next page token and build a string which can be injected into the request with it, unless it's None,
         # then let the whole thing be None so that the loop ends after this cycle


### PR DESCRIPTION
An api_request() function checks only for 429 error.
but, 403 error could also be found in response data(variable named 'request').
403 error has 'Access Not Configured. YouTube Data API has not been used in project 1034474976246 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/youtube.googleapis.com/overview?project=1034474976246 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.' message.

so, I think may be you could add 403 error check code in api_request() or just simply check if 'error' exist in response data(variable named 'video_data_page) as I added the code.